### PR TITLE
Open pop up coordinates for iOS

### DIFF
--- a/src/ios/FileOpener2.m
+++ b/src/ios/FileOpener2.m
@@ -36,10 +36,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 	NSString *path = [[command.arguments objectAtIndex:0] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
 	NSString *contentType = [command.arguments objectAtIndex:1];
+	NSArray *coords = [command.arguments objectAtIndex: 2];
 	BOOL showPreview = YES;
 
 	if ([command.arguments count] >= 3) {
-		showPreview = [[command.arguments objectAtIndex:2] boolValue];
+		showPreview = [[command.arguments objectAtIndex:3] boolValue];
 	}
 
 	CDVViewController* cont = (CDVViewController*)[super viewController];
@@ -84,6 +85,15 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 		} else {
 			CDVViewController* cont = self.cdvViewController;
 			CGRect rect = CGRectMake(0, 0, cont.view.bounds.size.width, cont.view.bounds.size.height);
+			
+			if (coords) {
+				rect = CGRectMake(
+					[[coords objectAtIndex:0] floatValue],
+					[[coords objectAtIndex:1] floatValue],
+					[[coords objectAtIndex:2] floatValue],
+					[[coords objectAtIndex:3] floatValue]);
+			}
+			
 			wasOpened = [docController presentOpenInMenuFromRect:rect inView:cont.view animated:YES];
 		}
 

--- a/www/plugins.FileOpener2.js
+++ b/www/plugins.FileOpener2.js
@@ -32,10 +32,10 @@ FileOpener2.prototype.open = function (fileName, contentType, callbackContext) {
     exec(callbackContext.success || null, callbackContext.error || null, 'FileOpener2', 'open', [fileName, contentType]);
 };
 
-FileOpener2.prototype.showOpenWithDialog = function (fileName, contentType, callbackContext) {
+FileOpener2.prototype.showOpenWithDialog = function (fileName, contentType, callbackContext, coords) {
     contentType = contentType || '';
     callbackContext = callbackContext || {};
-    exec(callbackContext.success || null, callbackContext.error || null, 'FileOpener2', 'open', [fileName, contentType, false]);
+    exec(callbackContext.success || null, callbackContext.error || null, 'FileOpener2', 'open', [fileName, contentType, coords || null, false]);
 };
 
 FileOpener2.prototype.uninstall = function (packageId, callbackContext) {


### PR DESCRIPTION
Feature: added the ability to pass in coordinates for the dialog to render at to showOpenWithDialog. (Fixes issue for iPad where dialog doesn't show) 